### PR TITLE
All installed files must now have #ddev-generated (#2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
 
   schedule:
   - cron: '01 07 * * *'
@@ -29,8 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        ddev_version: [stable, edge, HEAD]
-#        ddev_version: [PR]
+        ddev_version: [stable, HEAD]
+#        ddev_version: [stable, edge, HEAD, P]
       fail-fast: false
 
     runs-on: ubuntu-20.04

--- a/docker-compose.elasticsearch.yaml
+++ b/docker-compose.elasticsearch.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 version: '3.6'
 services:
   elasticsearch:

--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: addon-template
+name: ddev-elasticsearch
 
 pre_install_actions:
 


### PR DESCRIPTION
Signed-off-by: Randy Fay <randy@randyfay.com>

You'll want to apply these changes from ddev-elasticsearch, https://github.com/drud/ddev-elasticsearch/pull/2